### PR TITLE
Added null check to tSplitRow2Triple so that the triple is not created if the object is null

### DIFF
--- a/tSplitRow2Triple/tSplitRow2Triple_main.javajet
+++ b/tSplitRow2Triple/tSplitRow2Triple_main.javajet
@@ -50,15 +50,14 @@ if (listColMapping != null && !listColMapping.isEmpty())
 	// cache output rows for the loop
 	<%for (Map<String, String> colMapping : listColMapping) 
 	{ %>
-		rowTmp_<%=cid%> = new <%=outConnName%>Struct();
-		
-		rowTmp_<%=cid%> = new <%=outConnName%>Struct();
-		rowTmp_<%=cid%>.subject = <%=colMapping.get("subject")%>;
-		rowTmp_<%=cid%>.predicate=<%=colMapping.get("predicate")%>;
-		rowTmp_<%=cid%>.object=<%=colMapping.get("object")%>;
-		rowTmp_<%=cid%>.type=<%=colMapping.get("type")%>;
-		
-		rows_<%=cid%>.add(rowTmp_<%=cid%>);
+		if (<%=colMapping.get("object")%> != null && ! "".equals(<%=colMapping.get("object")%>)) {		
+			rowTmp_<%=cid%> = new <%=outConnName%>Struct();
+			rowTmp_<%=cid%>.subject = <%=colMapping.get("subject")%>;
+			rowTmp_<%=cid%>.predicate=<%=colMapping.get("predicate")%>;
+			rowTmp_<%=cid%>.object=<%=colMapping.get("object")%>.toString();
+			rowTmp_<%=cid%>.type=<%=colMapping.get("type")%>;
+			rows_<%=cid%>.add(rowTmp_<%=cid%>);
+		}
 		nb_line_<%=cid%>++;
 	<%
 	}


### PR DESCRIPTION
In tSplitRow2Triple a null pointer was happening if the row being passed had a null object - I added a simple null and empty String check so that it would skip that row in those circumstance.

This was satisfactory for my use case however may want to be enhanced in the future.